### PR TITLE
Allow JWKSet with single key without kid set.

### DIFF
--- a/src/JWKSet.php
+++ b/src/JWKSet.php
@@ -48,7 +48,7 @@ class JWKSet implements \Countable
      */
     public function hasDefaultKey() : bool
     {
-        return $this->count() == 1;
+        return $this->count() === 1;
     }
     
     /**
@@ -60,10 +60,9 @@ class JWKSet implements \Countable
         if (!$this->hasDefaultKey()) {
             throw new \RuntimeException("No default key");
         }
-        foreach ($this->keys as $jwk) {
-            return new JWK($jwk); //Return first JWK in Keys.
-        }
-        throw new \RuntimeException("Unreachable code reached");
+        reset($this->keys);
+
+        return new JWK(current($this->keys));
     }
 
     /**

--- a/src/JWKSet.php
+++ b/src/JWKSet.php
@@ -42,6 +42,29 @@ class JWKSet implements \Countable
 
         throw new RuntimeException('Unknown key');
     }
+    
+    /**
+     * @return bool
+     */
+    public function hasDefaultKey() : bool
+    {
+        return $this->count() == 1;
+    }
+    
+    /**
+     * @return JWK
+     * @throws RuntimeException
+     */
+    public function getDefaultKey() : JWK
+    {
+        if (!$this->hasDefaultKey()) {
+            throw new \RuntimeException("No default key");
+        }
+        foreach ($this->keys as $jwk) {
+            return new JWK($jwk); //Return first JWK in Keys.
+        }
+        throw new \RuntimeException("Unreachable code reached");
+    }
 
     /**
      * @return int

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -180,7 +180,7 @@ class JWT
             }
         } else {
             if ($publicKeyOrSecret instanceof JWKSet && !$publicKeyOrSecret->hasDefaultKey()) {
-                throw new InvalidJWT('No kid inside header, but $privateKeyOrSecret specified as JWKSet without default');
+                throw new InvalidJWT('No kid inside header, but $publicKeyOrSecret specified as JWKSet without default');
             }
         }
     }

--- a/src/JWT.php
+++ b/src/JWT.php
@@ -179,8 +179,8 @@ class JWT
                 throw new RuntimeException('Please specify jwk set in DecodeOptions, because there is kid inside header');
             }
         } else {
-            if ($publicKeyOrSecret instanceof JWKSet) {
-                throw new InvalidJWT('No kid inside header, but $privateKeyOrSecret specified as JWKSet');
+            if ($publicKeyOrSecret instanceof JWKSet && !$publicKeyOrSecret->hasDefaultKey()) {
+                throw new InvalidJWT('No kid inside header, but $privateKeyOrSecret specified as JWKSet without default');
             }
         }
     }
@@ -276,7 +276,11 @@ class JWT
         }
 
         if ($publicKeyOrSecret instanceof JWKSet) {
-            $jwk = $publicKeyOrSecret->findKeyByKid($this->headers['kid']);
+            if (isset($this->headers['kid'])) {
+                $jwk = $publicKeyOrSecret->findKeyByKid($this->headers['kid']);
+            } else {
+                $jwk = $publicKeyOrSecret->getDefaultKey();
+            }
             $secretOrKey = $jwk->getPublicKey();
         } else {
             $secretOrKey = $publicKeyOrSecret;

--- a/tests/JWKSetTest.php
+++ b/tests/JWKSetTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * SocialConnect project
+ */
+
+namespace Test\JWX;
+
+use DateTime;
+use SocialConnect\JWX\DecodeOptions;
+use SocialConnect\JWX\EncodeOptions;
+use SocialConnect\JWX\Exception\ExpiredJWT;
+use SocialConnect\JWX\Exception\InvalidJWT;
+use SocialConnect\JWX\JWK;
+use SocialConnect\JWX\JWKSet;
+use SocialConnect\JWX\JWT;
+
+class JWKSetTest extends AbstractTestCase {
+    
+    public function testDefaultKeyNoKeys() {
+        $set = new JWKSet(['keys' => []]);
+        
+        parent::assertFalse($set->hasDefaultKey());
+        
+        parent::expectException("RuntimeException");
+        $set->getDefaultKey();
+    }
+    
+    public function testDefaultKeyMultipleKeys() {
+        $set = new JWKSet(['keys' => [
+            JWK::fromRSAPublicKeyFile(__DIR__ . '/assets/rs256.key.pub')->toArray(),
+            JWK::fromRSAPublicKeyFile(__DIR__ . '/assets/rs384.key.pub')->toArray(),
+            
+        ]]);
+        
+        parent::assertFalse($set->hasDefaultKey());
+        
+        parent::expectException("RuntimeException");
+        $set->getDefaultKey();
+    }
+    
+    public function testDefaultKeySingle() {
+        $set = new JWKSet(['keys' => [
+            JWK::fromRSAPublicKeyFile(__DIR__ . '/assets/rs256.key.pub')->toArray(),
+            
+        ]]);
+        
+        parent::assertTrue($set->hasDefaultKey());
+        
+        parent::assertInstanceOf(JWK::class, $set->getDefaultKey());
+    }
+}

--- a/tests/JWTTest.php
+++ b/tests/JWTTest.php
@@ -212,6 +212,29 @@ class JWTTest extends AbstractTestCase
             new DecodeOptions(['RS256'])
         );
     }
+    
+    public function testValidateHeaderNoKidSingleKey()
+    {
+        $kset = new JWKSet(['keys' => [
+            JWK::fromRSAPublicKeyFile(__DIR__ . '/assets/rs512.key.pub')->toArray(),
+        ]]);
+        
+        $token = new JWT(
+            [],
+            [
+                'alg' => 'RS256'
+            ]
+        );
+
+        self::callProtectedMethod(
+            $token,
+            'validateHeader',
+            $kset,
+            new DecodeOptions(['RS256'])
+        );
+        
+        parent::assertTrue(true);
+    }
 
     public function testDecodeWrongNumberOfSegments()
     {


### PR DESCRIPTION
Fixes SocialConnect/auth#139.

Sadly I couldn't find any tests for `verifySignature` to extend for this case, so this is untested.