### PR TITLE
Use Base64url to encode headers and payload in `JWT::encode()`

### DIFF
--- a/src/JWT.php
+++ b/src/JWT.php
@@ -395,8 +395,8 @@ class JWT
             throw new InvalidJWT('Cannot encode payload to JSON');
         }
 
-        $header64 = base64_encode($headerStr);
-        $payload64 = base64_encode($payloadStr);
+        $header64 = JWT::urlsafeB64Encode($headerStr);
+        $payload64 = JWT::urlsafeB64Encode($payloadStr);
 
         $signature = $this->signature($privateKeyOrSecret, $alg, "{$header64}.{$payload64}");
         $signature64 = JWT::urlsafeB64Encode($signature);


### PR DESCRIPTION
... instead of using standard Base64.

Fixes SocialConnect/jwx#5.