### PR TITLE
Fix: Switch to Ubuntu 22.04 for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,15 @@ jobs:
 
     - name: Composer install
       run: |
-        if [[ ${{ matrix.php-version }} == '8.0' ]]; then
-          composer remove --dev squizlabs/php_codesniffer phpstan/phpstan-shim phpunit/phpunit
-          composer require --dev phpunit/phpunit:^8.5
-        else
-          composer update ${{ matrix.composer-opts }}
-        fi
+        case "${{ matrix.php-version }}" in
+          8*)
+            composer remove --dev squizlabs/php_codesniffer phpstan/phpstan-shim phpunit/phpunit
+            composer require --dev phpunit/phpunit:^8.5
+            ;;
+          *)
+            composer update ${{ matrix.composer-opts }}
+            ;;
+        esac
     - name: Run PHPUnit
       run: |
         if [[ ${{ matrix.php-version }} == '7.4' ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   testsuite:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.4', '8.0']
+        php-version: ['7.2', '7.4', '8.0', '8.1', '8.2']
         composer-opts: ['']
         include:
           - php-version: '7.1'


### PR DESCRIPTION
ci.yml currently requests Ubuntu 18.04 runners, but per https://github.com/actions/runner-images/issues/6002 Ubuntu 18.04 runners are now fully unsupported:
```
We have started the deprecation process for Ubuntu 18.04.
[...] the image will be fully unsupported by 2023/04/03
```

Fixes #7.