### PR TITLE
Fixing PHP 8.4 implicitly nullable parameters deprecation

### DIFF
--- a/src/Exception/ExpiredJWT.php
+++ b/src/Exception/ExpiredJWT.php
@@ -12,7 +12,7 @@ use Throwable;
 
 class ExpiredJWT extends RuntimeException
 {
-    public function __construct($message = 'Not Valid JWT', $code = 0, Throwable $previous = null)
+    public function __construct($message = 'Not Valid JWT', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/InvalidJWK.php
+++ b/src/Exception/InvalidJWK.php
@@ -12,7 +12,7 @@ use Throwable;
 
 class InvalidJWK extends RuntimeException
 {
-    public function __construct($message = 'Not Valid JWK', $code = 0, Throwable $previous = null)
+    public function __construct($message = 'Not Valid JWK', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/InvalidJWT.php
+++ b/src/Exception/InvalidJWT.php
@@ -12,7 +12,7 @@ use Throwable;
 
 class InvalidJWT extends RuntimeException
 {
-    public function __construct($message = 'Not Valid JWT', $code = 0, Throwable $previous = null)
+    public function __construct($message = 'Not Valid JWT', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/UnsupportedJWK.php
+++ b/src/Exception/UnsupportedJWK.php
@@ -12,7 +12,7 @@ use Throwable;
 
 class UnsupportedJWK extends RuntimeException
 {
-    public function __construct($message = 'Unsupported JWK', $code = 0, Throwable $previous = null)
+    public function __construct($message = 'Unsupported JWK', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/UnsupportedSignatureAlgorithm.php
+++ b/src/Exception/UnsupportedSignatureAlgorithm.php
@@ -10,7 +10,7 @@ use Throwable;
 
 class UnsupportedSignatureAlgorithm extends RuntimeException
 {
-    public function __construct($message = 'Unsupported signature algorithm', $code = 0, Throwable $previous = null)
+    public function __construct($message = 'Unsupported signature algorithm', $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }


### PR DESCRIPTION
PHP 8.4 deprecated [implicitly nullable parameters](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter).

The jwx package causes deprecation warnings because it provides several exceptions with `Throwable` parameters with nullable default values.

With this PR those parameters were made explicitly nullable.